### PR TITLE
Remove tty package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "jest": "29.7.0",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.2",
-    "tty": "1.0.1",
     "typescript": "5.3.3"
   },
   "homepage": "https://github.com/rhinodavid/jest-quiet-reporter",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,6 @@ devDependencies:
   ts-node:
     specifier: 10.9.2
     version: 10.9.2(@types/node@20.11.5)(typescript@5.3.3)
-  tty:
-    specifier: 1.0.1
-    version: 1.0.1
   typescript:
     specifier: 5.3.3
     version: 5.3.3
@@ -2184,10 +2181,6 @@ packages:
       typescript: 5.3.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: true
-
-  /tty@1.0.1:
-    resolution: {integrity: sha512-yCPqGIuidycVkRigBDshlGDLKu9+p4JKtBQijtYcI7ZnWwak56vwT7y7dGGTcxG+ecjxgWQOPWuvlePmxC5S2w==}
     dev: true
 
   /type-detect@4.0.8:

--- a/src/QuietReporter.ts
+++ b/src/QuietReporter.ts
@@ -15,7 +15,7 @@ import {
   separateMessageFromStack,
 } from "jest-message-util";
 import { clearLine, isInteractive } from "jest-util";
-import type { WriteStream } from "tty";
+import type { WriteStream } from "node:tty";
 import Status from "./Status";
 import getResultHeader from "./getResultHeader";
 import getSnapshotStatus from "./getSnapshotStatus";


### PR DESCRIPTION
I think the intent was always to import this directly from Node. The `tty` NPM package has been removed for security reasons (probably because it overloads the Node name) and points to https://github.com/npm/security-holder#readme.